### PR TITLE
商品一覧機能提出前

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all
+    @items = Item.order(created_at: :desc)
   end
 
   def new

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :user
+  belongs_to :shipping_fee
   has_one_attached :image
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,11 +129,10 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
   <% if @items.present? %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to item_path(item) do %>
+        <%# <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
 
@@ -156,14 +155,10 @@
             </div>
           </div>
         </div>
-        <% end %>
       </li>
       <% end %>
     <% else %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -182,8 +177,6 @@
         <% end %>
       </li>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,8 +130,10 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+  <% if @items.present? %>
+    <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
 
@@ -144,10 +146,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -156,6 +158,8 @@
         </div>
         <% end %>
       </li>
+      <% end %>
+    <% else %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
@@ -177,6 +181,7 @@
         </div>
         <% end %>
       </li>
+      <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>


### PR DESCRIPTION
お疲れ様です。
以下ご確認ください。

what
	•	トップページに商品一覧を表示する機能を実装
	•	出品された商品情報（画像・商品名・価格・配送料の負担）を新着順で表示
	•	商品が出品されていない場合は、ダミーの商品情報が表示される仕様を実装
	•	ログインしていないユーザーでも一覧を閲覧可能に設定
	•	売却済み商品の「sold out」表示は、購入機能実装後に対応予定
why
	•	ユーザーが出品されている商品を一覧で確認できるようにするため
	•	アプリケーションの利用者が、トップページからすぐに商品を閲覧・購入へと進めるようにするため
	•	商品が存在しない状態でもUIを維持するために、ダミー情報を表示する必要があるため
	•	商品の最新情報を確認しやすくするため、新しい順に並び替えを実装

ダミー
https://i.gyazo.com/fcf2fdee84f59d9a51510de6b73363cb.gif
正規
https://i.gyazo.com/15e13bbab273bb9e43bc34263cc48e5b.gif

