### PR TITLE
商品詳細表示提出前

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Things you may want to cover:
 | condition_id | integer   | null: false                    |
 | shipping_fee_id | integer | null: false                    |
 | prefecture_id | integer   | null: false                    |
-| delivery_days_id | integer | null: false                    |
+| delivery_day_id | integer | null: false                    |
 | price        | integer   | null: false                    |
 | user         | references | null: false, foreign_key: true |
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,7 +27,7 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :description, :category_id, :condition_id, :shipping_fee_id, :prefecture_id,
-                                 :delivery_days_id, :price, :image).merge(user_id: current_user.id)
+                                 :delivery_day_id, :price, :image).merge(user_id: current_user.id)
   end
   # permit以下のところがストロングパラメータ
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,7 +20,7 @@ class Item < ApplicationRecord
 
   validates :prefecture_id, presence: true
 
-  validates :delivery_days_id, presence: true
+  validates :delivery_day_id, presence: true
 
   validates :price, presence: true,
                     numericality: {
@@ -56,5 +56,5 @@ class Item < ApplicationRecord
   belongs_to :delivery_day
 
   # ジャンルの選択が「---」の時は保存できないようにする
-  validates :delivery_days_id, numericality: { other_than: 1 }
+  validates :delivery_day_id, numericality: { other_than: 1 }
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -132,7 +132,7 @@
   <% if @items.present? %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%# <%= link_to item_path(item) do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag "item-sample.png", class: "item-img" %>
 
@@ -157,6 +157,7 @@
         </div>
       </li>
       <% end %>
+    <% end %>
     <% else %>
 
       <li class='list'>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -80,7 +80,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:delivery_days_id, DeliveryDay.all, :id, :name, { prompt: "---" }, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_day_id, DeliveryDay.all, :id, :name, { prompt: "---" }, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -38,8 +38,9 @@
 
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
+
     <table class="detail-table">
       <tbody>
         <tr>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,10 +4,14 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+    <% if @item.image.attached? %>
+        <%= image_tag @item.image ,class:"item-box-img" %>
+    <% else %>
+        <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+    <% end %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -19,23 +23,19 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+  <% if user_signed_in? && current_user == @item.user %>
+    <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
 
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+  <% elsif user_signed_in?  && current_user != @item.user %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+  <% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -44,27 +44,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -91,7 +91,7 @@
       </p>
       <button type="submit" class="comment-btn">
         <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
+        <span>コメントする</span>
       </button>
     </form>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,14 +27,14 @@
       </span>
     </div>
 
-  <% if user_signed_in? && current_user == @item.user %>
+  <%# <% if user_signed_in? && current_user == @item.user %>
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
 
-  <% elsif user_signed_in?  && current_user != @item.user %>
+  <%# <% elsif user_signed_in?  && current_user != @item.user %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-  <% end %>
+  <%# <% end %>
 
 
     <div class="item-explain-box">
@@ -103,9 +103,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,9 +28,9 @@
     </div>
 
   <%# <% if user_signed_in? && current_user == @item.user %>
-    <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集",  "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
 
   <%# <% elsif user_signed_in?  && current_user != @item.user %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "posts#index"
   root to: "items#index"
-  resources :items, only: [:index, :show, :new, :create]
+  resources :items, only: [:index, :show, :new, :create, :edit, :update, :destroy]
   resources :users, only: [:show]  # ユーザーの詳細ページを追加
   resources :products, only: [:new, :create]
 end

--- a/db/migrate/20250401030034_rename_delivery_days_id_to_delivery_day_id_in_items.rb
+++ b/db/migrate/20250401030034_rename_delivery_days_id_to_delivery_day_id_in_items.rb
@@ -1,0 +1,5 @@
+class RenameDeliveryDaysIdToDeliveryDayIdInItems < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :items, :delivery_days_id, :delivery_day_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_03_25_002909) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_01_030034) do
   create_table "active_storage_attachments", charset: "utf8mb3", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -46,7 +46,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_03_25_002909) do
     t.integer "condition_id", null: false
     t.integer "shipping_fee_id", null: false
     t.integer "prefecture_id", null: false
-    t.integer "delivery_days_id", null: false
+    t.integer "delivery_day_id", null: false
     t.integer "price", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION


ログイン状態で詳細ページ
https://i.gyazo.com/e0c3ff494caf2987143e7967c476ff7d.gif

ログイン状態で他の人の詳細ページ
https://i.gyazo.com/d2533014262911ac8f258b84f09cbf97.gif

ログインしてない状態で詳細ページ
https://i.gyazo.com/1dc86a65087979ac2d461f0e3261167f.gif

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
はまだ商品購入機能が終わってません。

what
- 商品詳細表示機能の実装
- 出品された商品をクリックすると、詳細ページに遷移
- 商品に紐づいた情報（画像・名前・説明・価格・配送料など）を表示
- ログインユーザーと出品者の関係に応じて、編集・削除・購入ボタンを表示

why
- ユーザーが商品について詳しい情報を確認し、購入や編集などのアクションを取れるようにするため
- 出品者以外は購入、出品者は編集や削除の操作ができるようにするため