### PR TITLE
商品情報編集機能提出前

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,15 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:edit, :update, :show]
+  before_action :move_to_root, only: [:edit, :update]
+
+  def move_to_root
+    redirect_to root_path if current_user != @item.user
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
+  end  
 
   def index
     @items = Item.order(created_at: :desc)
@@ -21,6 +31,25 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+  end
+
+  # 編集画面表示
+  def edit
+
+  end
+
+  # 更新処理
+  def update
+    @item = Item.find(params[:id])
+    if current_user == @item.user
+      if @item.update(item_params)
+        redirect_to item_path(@item), notice: '更新が完了しました'
+      else
+        render :edit
+      end
+    else
+      redirect_to root_path
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,7 +30,7 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
+
   end
 
   # 編集画面表示
@@ -40,17 +40,13 @@ class ItemsController < ApplicationController
 
   # 更新処理
   def update
-    @item = Item.find(params[:id])
-    if current_user == @item.user
-      if @item.update(item_params)
-        redirect_to item_path(@item), notice: '更新が完了しました'
-      else
-        render :edit
-      end
+    if @item.update(item_params)
+      redirect_to item_path(@item), notice: '更新が完了しました'
     else
-      redirect_to root_path
+      render :edit
     end
   end
+  
 
   private
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,8 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= form_with model: @item, local: true, data: { turbo: false } do |f| %>
+      <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +20,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +30,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +49,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, { prompt: "---" }, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, { prompt: "---" }, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +70,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_id, ShippingFee.all, :id, :name, { prompt: "---" }, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, { prompt: "---" }, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:delivery_day_id, DeliveryDay.all, :id, :name, { prompt: "---" }, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +98,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,10 +138,11 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>
+
   <% end %>
 
   <footer class="items-sell-footer">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,14 +27,14 @@
       </span>
     </div>
 
-  <%# <% if user_signed_in? && current_user == @item.user %>
-    <%= link_to "商品の編集",  "#", method: :get, class: "item-red-btn" %>
+  <% if user_signed_in? && current_user == @item.user %>
+    <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
 
-  <%# <% elsif user_signed_in?  && current_user != @item.user %>
+  <% elsif user_signed_in?  && current_user != @item.user %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-  <%# <% end %>
+  <% end %>
 
 
     <div class="item-explain-box">


### PR DESCRIPTION
お疲れ様です。
商品情報編集機能が終わりました。

ページに移る
https://i.gyazo.com/0c7bd9fb42c4fc5872a1daf7e3fc2037.gif
商品の情報編集
https://i.gyazo.com/d545f2cf066d8394b2cfb3d56c8e8289.gif
エラーメッセージ
https://i.gyazo.com/4bc87727b2d666cc9290a4723a99fffc.gif
何も編集しなくても元の表示
https://i.gyazo.com/ee6cea5e4a896bf1636f9b7fc2d2de86.gif
他の人の編集ページに行こうとするとトップに戻される
https://i.gyazo.com/956dfeb2c919e9b2ccde479ec0da982b.gif
未ログインの人が編集ページに行こうとするとログインページに移る
https://i.gyazo.com/79e8676a71f4f61fcd32e42c60aa843e.gif
編集を押すと情報が残っている
https://i.gyazo.com/046487944e9ff43d3fabe10fd93efe61.gif

what
- 商品情報を編集できる機能を実装しました。
- 編集フォームでは、すでに登録された商品情報があらかじめ表示されるようにしています。
- エラーハンドリングを追加し、不正な入力時にエラーメッセージが表示され、編集ページに戻るようにしています。
- 編集が完了すると、商品詳細ページに遷移するように設定しました。
- 「もどる」ボタンを押すと、編集内容は破棄され、商品詳細ページへ遷移します。

why
- 出品者が商品情報を後から変更できるようにするため。
- 編集時に商品情報が保持されていないと、ユーザーが再入力する必要があり、ユーザビリティが低下するため。
- 不正アクセス（他ユーザーの商品を編集しようとした場合）や未ログイン時のアクセス制限をかけ、セキュリティを保つため。
