### PR TITLE
商品削除機能提出前

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:edit, :update, :show]
-  before_action :move_to_root, only: [:edit, :update]
+  before_action :set_item, only: [:edit, :update, :show, :destroy]
+  before_action :move_to_root, only: [:edit, :update, :destroy]
 
   def move_to_root
     redirect_to root_path if current_user != @item.user
@@ -47,6 +47,16 @@ class ItemsController < ApplicationController
     end
   end
   
+  def destroy
+    @item = Item.find(params[:id])
+    if current_user == @item.user
+      @item.destroy
+      redirect_to root_path, notice: '商品を削除しました'
+    else
+      redirect_to root_path, alert: '権限がありません'
+    end
+  end
+
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_item, only: [:edit, :update, :show, :destroy]
   before_action :move_to_root, only: [:edit, :update, :destroy]
 
@@ -48,7 +48,6 @@ class ItemsController < ApplicationController
   end
   
   def destroy
-    @item = Item.find(params[:id])
     if current_user == @item.user
       @item.destroy
       redirect_to root_path, notice: '商品を削除しました'
@@ -56,7 +55,6 @@ class ItemsController < ApplicationController
       redirect_to root_path, alert: '権限がありません'
     end
   end
-
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
   <% if user_signed_in? && current_user == @item.user %>
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item),method: :delete, data: {turbo_method: :delete}, class:"item-destroy" %>
 
   <% elsif user_signed_in?  && current_user != @item.user %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
商品削除
https://i.gyazo.com/d94c8bc972cfc31fa8045b4dcb6f8f46.gif

what
商品削除機能を実装する。
具体的には、ログインしているユーザーが、自身が出品した商品の詳細ページから「削除」ボタンを押すことで、その商品を削除できるようにする。

why
	•	不要になった商品や間違って出品した商品を、ユーザーが自身で削除できるようにするため。
	•	フリマアプリとしての基本的な機能のひとつであり、ユーザーにとって使いやすくするため。
	•	「ログインユーザーかつ出品者のみ削除可能」にすることで、不正操作（第三者による削除）を防ぐため。
